### PR TITLE
Version 0.0.3 Async Video Upload

### DIFF
--- a/TwVideoUp/Core/MediaAsyncExtend.cs
+++ b/TwVideoUp/Core/MediaAsyncExtend.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CoreTweet;
+using CoreTweet.Core;
+using CoreTweet.Rest;
+using TwVideoUp.util;
+
+namespace TwVideoUp.Core
+{
+    public partial class MediaAsyncExtend
+    {
+        public MediaAsyncExtend(Tokens token)
+        {
+            coreTweeTokens = token;
+        }
+
+        private Tokens coreTweeTokens;
+
+        public Task<UploadFinalizeCommandResult> UploadChunkedAsync(Stream media, long totalBytes, UploadMediaType mediaType,
+            IEnumerable<KeyValuePair<string, object>> parameters, CancellationToken cancellationToken)
+        {
+            return coreTweeTokens.Media.UploadInitCommandAsync(parameters.EndWith(
+                new KeyValuePair<string, object>("total_bytes", totalBytes),
+                new KeyValuePair<string, object>("media_type", mediaType)
+                ), cancellationToken)
+                .Done(result =>
+                {
+                    const int maxChunkSize = 5*1000*1000;
+                    var tasks = new List<Task>((int) (totalBytes/maxChunkSize) + 1);
+                    var sem = new Semaphore(2, 2);
+                    var remainingBytes = totalBytes;
+
+                    for (var segmentIndex = 0; remainingBytes > 0; segmentIndex++)
+                    {
+                        sem.WaitOne();
+                        var chunkSize = (int) Math.Min(remainingBytes, maxChunkSize);
+                        var chunk = new byte[chunkSize];
+                        var readCount = media.Read(chunk, 0, chunkSize);
+                        if (readCount == 0) break;
+                        remainingBytes -= readCount;
+                        tasks.Add(
+                            coreTweeTokens.Media.UploadAppendCommandAsync(
+                                new Dictionary<string, object>
+                                {
+                                    {"media_id", result.MediaId},
+                                    {"segment_index", segmentIndex},
+                                    {"media", new ArraySegment<byte>(chunk, 0, readCount)}
+                                },
+                                cancellationToken
+                                ).ContinueWith(t =>
+                                {
+                                    sem.Release();
+                                    return t;
+                                }).Unwrap()
+                            );
+                    }
+                    return Task.WhenAll(tasks)
+                        .Done(() => coreTweeTokens.Media.UploadFinalizeCommandAsync(result.MediaId, cancellationToken),
+                            cancellationToken)
+                        .Unwrap();
+                }, cancellationToken, true).Unwrap();
+        }
+
+        private Task<MediaUploadResult> WaitForProcessing(long mediaId, CancellationToken cancellationToken)
+        {
+            return coreTweeTokens.Media.UploadStatusCommandAsync(mediaId, cancellationToken)
+                .Done(x =>
+                {
+                    if (x.ProcessingInfo?.State == "failed")
+                        throw new MediaProcessingException(x);
+
+                    if (x.ProcessingInfo?.CheckAfterSecs != null)
+                    {
+                        return InternalUtils.Delay(x.ProcessingInfo.CheckAfterSecs.Value*1000, cancellationToken)
+                            .Done(() => this.WaitForProcessing(mediaId, cancellationToken), cancellationToken)
+                            .Unwrap();
+                    }
+
+                    return Task.FromResult<MediaUploadResult>(x);
+                }, cancellationToken)
+                .Unwrap();
+        }
+    }
+
+    internal static class EnumerableExtensions
+    {
+        internal static IEnumerable<string> EnumerateLines(this StreamReader streamReader)
+        {
+            while (!streamReader.EndOfStream)
+                yield return streamReader.ReadLine();
+        }
+
+        internal static void ForEach<T>(this IEnumerable<T> source, Action<T> action)
+        {
+            foreach (T item in source)
+                action(item);
+        }
+
+        internal static string JoinToString<T>(this IEnumerable<T> source)
+        {
+#if !NET35
+            return string.Concat(source);
+#else
+            return string.Concat(source.Cast<object>().ToArray());
+#endif
+        }
+
+        internal static string JoinToString<T>(this IEnumerable<T> source, string separator)
+        {
+#if !NET35
+            return string.Join(separator, source);
+#else
+            return string.Join(separator, source.Select(x => x.ToString()).ToArray());
+#endif
+        }
+
+        internal static IEnumerable<T> EndWith<T>(this IEnumerable<T> source, params T[] second)
+        {
+            return source.Concat(second);
+        }
+    }
+
+    internal struct Unit
+    {
+        internal static readonly Unit Default = new Unit();
+    }
+
+    internal static class TaskExtensions
+    {
+        internal static Task<TResult> Done<TSource, TResult>(this Task<TSource> source, Func<TSource, TResult> action,
+            CancellationToken cancellationToken, bool longRunning = false)
+        {
+            var tcs = new TaskCompletionSource<TResult>();
+            source.ContinueWith(t =>
+            {
+                if (t.IsCanceled || cancellationToken.IsCancellationRequested)
+                {
+                    tcs.TrySetCanceled();
+                    return;
+                }
+
+                if (t.Exception != null)
+                {
+                    tcs.TrySetException(t.Exception.InnerExceptions.Count == 1
+                        ? t.Exception.InnerException
+                        : t.Exception);
+                    return;
+                }
+
+                try
+                {
+                    tcs.TrySetResult(action(t.Result));
+                }
+                catch (OperationCanceledException)
+                {
+                    tcs.TrySetCanceled();
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, longRunning ? TaskContinuationOptions.LongRunning : TaskContinuationOptions.ExecuteSynchronously);
+            return tcs.Task;
+        }
+
+        internal static Task Done<TSource>(this Task<TSource> source, Action<TSource> action,
+            CancellationToken cancellationToken, bool longRunning = false)
+        {
+            var tcs = new TaskCompletionSource<Unit>();
+            source.ContinueWith(t =>
+            {
+                if (t.IsCanceled || cancellationToken.IsCancellationRequested)
+                {
+                    tcs.TrySetCanceled();
+                    return;
+                }
+
+                if (t.Exception != null)
+                {
+                    tcs.TrySetException(t.Exception.InnerExceptions.Count == 1
+                        ? t.Exception.InnerException
+                        : t.Exception);
+                    return;
+                }
+
+                try
+                {
+                    action(t.Result);
+                    tcs.TrySetResult(Unit.Default);
+                }
+                catch (OperationCanceledException)
+                {
+                    tcs.TrySetCanceled();
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, longRunning ? TaskContinuationOptions.LongRunning : TaskContinuationOptions.ExecuteSynchronously);
+            return tcs.Task;
+        }
+
+        internal static Task<TResult> Done<TResult>(this Task source, Func<TResult> action,
+            CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<TResult>();
+            source.ContinueWith(t =>
+            {
+                if (t.IsCanceled || cancellationToken.IsCancellationRequested)
+                {
+                    tcs.TrySetCanceled();
+                    return;
+                }
+
+                if (t.Exception != null)
+                {
+                    tcs.TrySetException(t.Exception.InnerExceptions.Count == 1
+                        ? t.Exception.InnerException
+                        : t.Exception);
+                    return;
+                }
+
+                try
+                {
+                    tcs.TrySetResult(action());
+                }
+                catch (OperationCanceledException)
+                {
+                    tcs.TrySetCanceled();
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, TaskContinuationOptions.ExecuteSynchronously);
+            return tcs.Task;
+        }
+    }
+}

--- a/TwVideoUp/MainWindow.xaml.cs
+++ b/TwVideoUp/MainWindow.xaml.cs
@@ -355,7 +355,7 @@ namespace TwVideoUp
                 {
                     if (uploadStatus.ProcessingInfo.ProgressPercent != null)
                         SetProgress(uploadStatus.ProcessingInfo.ProgressPercent.Value);
-                    await Task.Delay(uploadStatus.ProcessingInfo.CheckAfterSecs);
+                    await Task.Delay(uploadStatus.ProcessingInfo.CheckAfterSecs*1000);
                 }
 
                 Status s = await tokens.Statuses.UpdateAsync(

--- a/TwVideoUp/MainWindow.xaml.cs
+++ b/TwVideoUp/MainWindow.xaml.cs
@@ -35,7 +35,7 @@ namespace TwVideoUp
         public MainWindow()
         {
             InitializeComponent();
-             var status = new StatusWM
+            var status = new StatusWM
             {
                 Status = "",
                 Media = null,
@@ -51,13 +51,10 @@ namespace TwVideoUp
 
             ContextMenuGen();
 
-            tokens = Tokens.Create(Twitter.CK, Twitter.CS, 
-                Settings.Default.token, 
+            tokens = Tokens.Create(Twitter.CK, Twitter.CS,
+                Settings.Default.token,
                 Settings.Default.secret
                 );
-
-
-
         }
 
         private static void AuthStart()
@@ -74,7 +71,7 @@ namespace TwVideoUp
             if (Settings.Default.token == "")
             {
 #if DEBUG
-                MessageBox.Show("認証が完了していません");           
+                MessageBox.Show("認証が完了していません");
 #else
                 MessageBoxResult result = MessageBox.Show(Properties.Resources.MsgUnAuth, Properties.Resources.Attention,
                     MessageBoxButton.YesNo, MessageBoxImage.Warning);
@@ -115,7 +112,7 @@ namespace TwVideoUp
             };
             menuItemCheckable.SetBinding(MenuItem.IsCheckedProperty, new Binding("Check"));
             menu.Items.Add(menuItemCheckable);
-            
+
             // Re-Auth
             MenuItem menuItemReAuth = new MenuItem();
             menuItemReAuth.Header = Properties.Resources.menuReauth;
@@ -123,7 +120,7 @@ namespace TwVideoUp
             menu.Items.Add(menuItemReAuth);
             // About APP
             MenuItem menuItemAbout = new MenuItem();
-            menuItemAbout.Header = String.Format(Properties.Resources.AboutThis, "TwVideoUp");
+            menuItemAbout.Header = string.Format(Properties.Resources.AboutThis, "TwVideoUp");
             menuItemAbout.Click += AboutApp;
             menu.Items.Add(menuItemAbout);
 
@@ -142,7 +139,6 @@ namespace TwVideoUp
                 Settings.Default.token,
                 Settings.Default.secret
                 );
-
         }
 
         /// <summary>
@@ -186,7 +182,7 @@ namespace TwVideoUp
             context.Media = new Uri(filename);
             FileInfo fi = new FileInfo(filename);
             long fileSize = fi.Length;
-            if(fileSize > 500*1024*1024)
+            if (fileSize > 500*1024*1024)
             {
 //                MessageBox.Show(Properties.Resources.FileSizeTooLarge, Properties.Resources.Attention);
                 Dialog(Properties.Resources.Attention, Properties.Resources.InsFileSizeTooLarge,
@@ -200,7 +196,6 @@ namespace TwVideoUp
             }
             Console.WriteLine(mediaElement.Height);
             mediaElement.Source = context.Media;
-
         }
 
         /// <summary>
@@ -218,7 +213,7 @@ namespace TwVideoUp
             };
 
             bool? res = fileDialog.ShowDialog();
-            if(res == true)
+            if (res == true)
             {
                 return fileDialog.FileName;
             }
@@ -238,19 +233,17 @@ namespace TwVideoUp
         {
             if (e.Data.GetDataPresent(DataFormats.FileDrop))
             {
-                string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                string[] files = (string[]) e.Data.GetData(DataFormats.FileDrop);
 
                 if (files[0].EndsWith(".mp4") && File.Exists(@files[0]))
                 {
-                    if (DataContext != null) mediaElement.Source = ((StatusWM)DataContext).Media = new Uri(files[0]);
+                    if (DataContext != null) mediaElement.Source = ((StatusWM) DataContext).Media = new Uri(files[0]);
                 }
                 else
                 {
                     Dialog("Please drop mp4 video", "Invalid extension", "Only mp4 can upload",
                         TaskDialogStandardIcon.Error).Show();
                 }
-
-
             }
             else
             {
@@ -270,7 +263,7 @@ namespace TwVideoUp
         /// <param name="e"></param>
         private void m_PauseButton_Click(object sender, RoutedEventArgs e)
         {
-            if(mediaElement.IsLoaded)
+            if (mediaElement.IsLoaded)
                 mediaElement.Pause();
         }
 
@@ -281,7 +274,7 @@ namespace TwVideoUp
         /// <param name="e"></param>
         private void m_PlayButton_Click(object sender, RoutedEventArgs e)
         {
-            if(mediaElement.IsLoaded)
+            if (mediaElement.IsLoaded)
                 mediaElement.Play();
         }
 
@@ -295,7 +288,7 @@ namespace TwVideoUp
         /// 新しいウインドウでプレビュー
         /// </summary>
         /// <param name="uri"></param>
-        private void openMediaPreviewWindow (Uri uri)
+        private void openMediaPreviewWindow(Uri uri)
         {
             MediaElement media = new MediaElement {Source = uri};
             Window c = new Window
@@ -305,14 +298,12 @@ namespace TwVideoUp
                 WindowStyle = WindowStyle.ToolWindow
             };
             c.Show();
-
         }
 
         private void mediaElement_SourceUpdated(object sender, DataTransferEventArgs e)
         {
             mediaElement.Play();
             mediaElement.Pause();
-
         }
 
         /// <summary>
@@ -346,17 +337,14 @@ namespace TwVideoUp
 //                MessageBox.Show(fi.FullName);
 //                MessageBox.Show(fi.Length.ToString());                     
                 MediaUploadResult result =
-                    await
-                        tokens.Media.UploadChunkedAsync(fi.OpenRead(), fi.Length, UploadMediaType.Video,
-                            new {media_category = "tweet_video"}, CancellationToken.None);
-                UploadStatusCommandResult uploadStatus;
-                while ((uploadStatus = ( await tokens.Media.UploadStatusCommandAsync(result.MediaId)))?.ProcessingInfo?.State ==
-                       "in_progress")
-                {
-                    if (uploadStatus.ProcessingInfo.ProgressPercent != null)
-                        SetProgress(uploadStatus.ProcessingInfo.ProgressPercent.Value);
-                    await Task.Delay(uploadStatus.ProcessingInfo.CheckAfterSecs*1000);
-                }
+                    await tokens.Media.UploadChunkedAsync(fi.OpenRead(), fi.Length, UploadMediaType.Video, "tweet_video");
+//                UploadStatusCommandResult uploadStatus;
+//                while ((uploadStatus = (await tokens.Media.UploadStatusCommandAsync(result.MediaId)))?.ProcessingInfo.State =="in_progress")
+//                {
+//                    if (uploadStatus.ProcessingInfo.ProgressPercent != null)
+//                        SetProgress(uploadStatus.ProcessingInfo.ProgressPercent.Value);
+//                    await Task.Delay(uploadStatus.ProcessingInfo.CheckAfterSecs*1000);
+//                }
 
                 Status s = await tokens.Statuses.UpdateAsync(
                     status => text,
@@ -365,9 +353,8 @@ namespace TwVideoUp
                 AfterSendTweet(SUCCESS);
                 // めんどくさいのでツイート処理は別添え
                 SucceedUpload(s);
-
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 AfterSendTweet(FAIL);
                 Console.WriteLine(e.StackTrace);
@@ -393,7 +380,6 @@ namespace TwVideoUp
         {
             var dc = DataContext as StatusWM;
             updateWithMedia(dc.Status, dc.Media);
-
         }
 
         /// <summary>
@@ -403,7 +389,7 @@ namespace TwVideoUp
         {
             SendTweetButton.IsEnabled = false;
             PGbar.IsIndeterminate = true;
-            TaskbarItemInfo.ProgressState=TaskbarItemProgressState.Indeterminate;
+            TaskbarItemInfo.ProgressState = TaskbarItemProgressState.Indeterminate;
         }
 
         /// <summary>
@@ -424,25 +410,22 @@ namespace TwVideoUp
         /// <param name="status">成否</param>
         private void AfterSendTweet(int status)
         {
-            
             if (status == SUCCESS)
             {
                 StatusWM dc = DataContext as StatusWM;
                 dc.Media = null;
                 dc.Status = "";
                 StatusArea.Text = "";
-
             }
             PGbar.IsIndeterminate = false;
             PGbar.Value = 0;
             SendTweetButton.IsEnabled = true;
-            TaskbarItemInfo.ProgressState=TaskbarItemProgressState.None;
+            TaskbarItemInfo.ProgressState = TaskbarItemProgressState.None;
             TaskbarItemInfo.ProgressValue = 0;
         }
 
         private void ProgressBar_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-
         }
 
         /// <summary>
@@ -482,6 +465,5 @@ namespace TwVideoUp
             };
             return dialog;
         }
-
     }
 }

--- a/TwVideoUp/MainWindow.xaml.cs
+++ b/TwVideoUp/MainWindow.xaml.cs
@@ -186,7 +186,7 @@ namespace TwVideoUp
             context.Media = new Uri(filename);
             FileInfo fi = new FileInfo(filename);
             long fileSize = fi.Length;
-            if (fileSize > 500*1024*1024)
+            if (fileSize > 512*1024*1024)
             {
 //                MessageBox.Show(Properties.Resources.FileSizeTooLarge, Properties.Resources.Attention);
                 Dialog(Properties.Resources.Attention, Properties.Resources.InsFileSizeTooLarge,

--- a/TwVideoUp/Properties/AssemblyInfo.cs
+++ b/TwVideoUp/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // すべての値を指定するか、下のように '*' を使ってビルドおよびリビジョン番号を 
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.2.*")]
-[assembly: AssemblyFileVersion("0.0.2")]
+[assembly: AssemblyVersion("0.0.3.*")]
+[assembly: AssemblyFileVersion("0.0.3")]

--- a/TwVideoUp/Properties/Resources.Designer.cs
+++ b/TwVideoUp/Properties/Resources.Designer.cs
@@ -29,7 +29,7 @@ namespace TwVideoUp.Properties {
         private static global::System.Globalization.CultureInfo resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        public Resources() {
+        internal Resources() {
         }
         
         /// <summary>
@@ -106,7 +106,7 @@ namespace TwVideoUp.Properties {
         }
         
         /// <summary>
-        ///   Must less than 15MB :( に類似しているローカライズされた文字列を検索します。
+        ///   Must less than 500MB :( に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string FileSizeTooLarge {
             get {
@@ -133,7 +133,7 @@ namespace TwVideoUp.Properties {
         }
         
         /// <summary>
-        ///   Must less than 30 sec :( に類似しているローカライズされた文字列を検索します。
+        ///   Must less than 140 sec :( に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string MediaTooLong {
             get {

--- a/TwVideoUp/Properties/Resources.Designer.cs
+++ b/TwVideoUp/Properties/Resources.Designer.cs
@@ -29,7 +29,7 @@ namespace TwVideoUp.Properties {
         private static global::System.Globalization.CultureInfo resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources() {
+        public Resources() {
         }
         
         /// <summary>

--- a/TwVideoUp/Properties/Resources.ja-JP.resx
+++ b/TwVideoUp/Properties/Resources.ja-JP.resx
@@ -124,7 +124,7 @@
     <value>警告</value>
   </data>
   <data name="FileSizeTooLarge" xml:space="preserve">
-    <value>ファイルサイズは15MB以下にする必要があります</value>
+    <value>ファイルサイズは500MB以下にする必要があります</value>
   </data>
   <data name="InsFileSizeTooLarge" xml:space="preserve">
     <value>ファイルサイズが大きすぎます！</value>
@@ -133,7 +133,7 @@
     <value>再生時間が長すぎます！</value>
   </data>
   <data name="MediaTooLong" xml:space="preserve">
-    <value>アップロードする動画は30秒以下にしてください。</value>
+    <value>アップロードする動画は140秒以下にしてください。</value>
   </data>
   <data name="menuReauth" xml:space="preserve">
     <value>再認証 (アカウントの切り替え)</value>

--- a/TwVideoUp/Properties/Resources.resx
+++ b/TwVideoUp/Properties/Resources.resx
@@ -124,7 +124,7 @@
     <value>Attention</value>
   </data>
   <data name="FileSizeTooLarge" xml:space="preserve">
-    <value>Must less than 15MB :(</value>
+    <value>Must less than 500MB :(</value>
   </data>
   <data name="menuReauth" xml:space="preserve">
     <value>Re-Login (Change Account)</value>
@@ -139,7 +139,7 @@
     <value>Media Duration is too long</value>
   </data>
   <data name="MediaTooLong" xml:space="preserve">
-    <value>Must less than 30 sec :(</value>
+    <value>Must less than 140 sec :(</value>
   </data>
   <data name="menuCheck" xml:space="preserve">
     <value>Check URL After Send Tweet</value>

--- a/TwVideoUp/TwVideoUp.csproj
+++ b/TwVideoUp/TwVideoUp.csproj
@@ -65,20 +65,19 @@
     <ApplicationIcon>Resources\appicon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CoreTweet, Version=0.5.4.33371, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CoreTweet.0.5.4-beta2\lib\net45\CoreTweet.dll</HintPath>
+    <Reference Include="CoreTweet, Version=0.6.2.19552, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CoreTweet.0.6.2\lib\net45\CoreTweet.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAPICodePack-Core.1.1.1\lib\Microsoft.WindowsAPICodePack.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAPICodePack">
+      <HintPath>..\packages\WindowsAPICodePack-Core.1.1.2\lib\Microsoft.WindowsAPICodePack.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAPICodePack.Shell, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAPICodePack-Shell.1.1.1\lib\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.1-beta1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/TwVideoUp/TwVideoUp.csproj
+++ b/TwVideoUp/TwVideoUp.csproj
@@ -65,8 +65,8 @@
     <ApplicationIcon>Resources\appicon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CoreTweet, Version=0.6.2.19552, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CoreTweet.0.6.2\lib\net45\CoreTweet.dll</HintPath>
+    <Reference Include="CoreTweet, Version=0.6.4.304, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CoreTweet.0.6.4.304\lib\net45\CoreTweet.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAPICodePack">

--- a/TwVideoUp/TwVideoUp.csproj
+++ b/TwVideoUp/TwVideoUp.csproj
@@ -107,12 +107,14 @@
     <Compile Include="AuthWindow.xaml.cs">
       <DependentUpon>AuthWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Core\MediaAsyncExtend.cs" />
     <Compile Include="Core\Twitter.cs" />
     <Compile Include="EntitiesInfoWindow.xaml.cs">
       <DependentUpon>EntitiesInfoWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Settings.cs" />
     <Compile Include="StatusWM.cs" />
+    <Compile Include="util\InternalUtils.cs" />
     <Page Include="AboutApp.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/TwVideoUp/packages.config
+++ b/TwVideoUp/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CoreTweet" version="0.5.4-beta2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.1-beta1" targetFramework="net45" />
-  <package id="WindowsAPICodePack-Core" version="1.1.1" targetFramework="net45" />
+  <package id="CoreTweet" version="0.6.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="WindowsAPICodePack-Core" version="1.1.2" targetFramework="net45" />
   <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net45" />
 </packages>

--- a/TwVideoUp/packages.config
+++ b/TwVideoUp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CoreTweet" version="0.6.2" targetFramework="net45" />
+  <package id="CoreTweet" version="0.6.4.304" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="WindowsAPICodePack-Core" version="1.1.2" targetFramework="net45" />
   <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net45" />

--- a/TwVideoUp/util/InternalUtils.cs
+++ b/TwVideoUp/util/InternalUtils.cs
@@ -1,0 +1,437 @@
+﻿// The MIT License (MIT)
+//
+// CoreTweet - A .NET Twitter Library supporting Twitter API 1.1
+// Copyright (c) 2013-2016 CoreTweet Development Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CoreTweet;
+using CoreTweet.Core;
+using TwVideoUp.Core;
+
+#if !NET35
+
+#endif
+
+namespace TwVideoUp.util
+{
+    internal static class InternalUtils
+    {
+        internal static IEnumerable<KeyValuePair<string, object>> ResolveObject(object t)
+        {
+            if (t == null)
+                return new Dictionary<string, object>();
+            var ie = t as IEnumerable<KeyValuePair<string, object>>;
+            if (ie != null) return ie;
+
+#if WIN_RT || PCL
+            var type = t.GetType().GetTypeInfo();
+#else
+            var type = t.GetType();
+#endif
+
+            if (type.GetCustomAttributes(typeof(TwitterParametersAttribute), false).Any())
+            {
+                var d = new Dictionary<string, object>();
+
+#if WIN_RT || PCL
+                foreach(var f in type.DeclaredFields.Where(x => x.IsPublic && !x.IsStatic))
+#else
+                foreach (var f in type.GetFields(BindingFlags.Instance | BindingFlags.Public))
+#endif
+                {
+                    var attr = f.GetCustomAttributes(true).OfType<TwitterParameterAttribute>().FirstOrDefault();
+                    var value = f.GetValue(t);
+                    if (attr != null && value != null)
+                    {
+                        var defaultValue = attr.DefaultValue ?? GetDefaultValue(t.GetType());
+                        if (!value.Equals(defaultValue))
+                            d.Add(attr.Name ?? f.Name, value);
+                    }
+                }
+
+#if WIN_RT || PCL
+                foreach(var p in type.DeclaredProperties.Where(x => x.CanRead && x.GetMethod.IsPublic && !x.GetMethod.IsStatic))
+#else
+                foreach (var p in type.GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(x => x.CanRead))
+#endif
+                {
+                    var attr = p.GetCustomAttributes(true).OfType<TwitterParameterAttribute>().FirstOrDefault();
+                    var value = p.GetValue(t, null);
+                    if (attr != null && value != null)
+                    {
+                        var defaultValue = attr.DefaultValue ?? GetDefaultValue(t.GetType());
+                        if (!value.Equals(defaultValue))
+                            d.Add(attr.Name ?? p.Name, value);
+                    }
+                }
+
+                return d;
+            }
+
+            // IEnumerable<KeyVakuePair<string, Any>> or IEnumerable<Tuple<string, Any>>
+            var ienumerable = t as System.Collections.IEnumerable;
+            if (ienumerable != null)
+            {
+                var elements = ienumerable.Cast<object>();
+                var ieElementTypes =
+                    type.GetInterfaces()
+                    .Where(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+#if WIN_RT || PCL
+                    .Select(x => x.GenericTypeArguments[0].GetTypeInfo())
+                    .Where(x => x.IsGenericType && x.GenericTypeArguments[0] == typeof(string));
+#else
+                    .Select(x => x.GetGenericArguments()[0])
+                    .Where(x => x.IsGenericType && x.GetGenericArguments()[0] == typeof(string));
+#endif
+                foreach (var genericElement in ieElementTypes)
+                {
+                    var genericTypeDefinition = genericElement.GetGenericTypeDefinition();
+                    if (genericTypeDefinition == typeof(KeyValuePair<,>))
+                    {
+                        var getKey = genericElement.GetProperty("Key").GetGetMethod();
+                        var getValue = genericElement.GetProperty("Value").GetGetMethod();
+                        return elements.Select(x => new KeyValuePair<string, object>(
+                            (string)getKey.Invoke(x, null),
+                            getValue.Invoke(x, null)
+                        ));
+                    }
+#if !NET35
+                    if (genericTypeDefinition == typeof(Tuple<,>))
+                    {
+                        var getItem1 = genericElement.GetProperty("Item1").GetGetMethod();
+                        var getItem2 = genericElement.GetProperty("Item2").GetGetMethod();
+                        return elements.Select(x => new KeyValuePair<string, object>(
+                            (string)getItem1.Invoke(x, null),
+                            getItem2.Invoke(x, null)
+                        ));
+                    }
+#endif
+                }
+            }
+
+#if !NET35
+            // Tuple<Tuple<string, Any>, Tuple<string, Any>, ...>
+            if (type.Namespace == "System" && type.Name.StartsWith("Tuple`", StringComparison.Ordinal))
+            {
+                var items = EnumerateTupleItems(t).ToArray();
+                try
+                {
+                    return items.Select(x =>
+                    {
+                        var xtype = x.GetType();
+                        return new KeyValuePair<string, object>(
+#if WIN_RT || PCL
+                            (string)xtype.GetRuntimeProperty("Item1").GetValue(x),
+                            xtype.GetRuntimeProperty("Item2").GetValue(x)
+#else
+                            (string)xtype.GetProperty("Item1").GetValue(x, null),
+                            xtype.GetProperty("Item2").GetValue(x, null)
+#endif
+                        );
+                    }).ToArray();
+                }
+                catch
+                {
+                    return ResolveObject(items);
+                }
+            }
+#endif
+
+            return AnnoToDictionary(t);
+        }
+
+        private static IDictionary<string, object> AnnoToDictionary(object f)
+        {
+#if WIN_RT || PCL
+            return f.GetType().GetRuntimeProperties()
+                .Where(x => x.CanRead && x.GetIndexParameters().Length == 0)
+                .Select(x => Tuple.Create(x.Name, x.GetMethod))
+                .Where(x => x.Item2.IsPublic && !x.Item2.IsStatic)
+                .ToDictionary(x => x.Item1, x => x.Item2.Invoke(f, null));
+#else
+            return f.GetType().GetProperties()
+                .Where(x => x.CanRead && x.GetIndexParameters().Length == 0)
+                .ToDictionary(x => x.Name, x => x.GetValue(f, null));
+#endif
+        }
+
+#if !NET35
+        private static IEnumerable<object> EnumerateTupleItems(object tuple)
+        {
+            while (true)
+            {
+#if WIN_RT || PCL
+                var type = tuple.GetType().GetTypeInfo();
+                var props = type.DeclaredProperties;
+#else
+                var type = tuple.GetType();
+                var props = type.GetProperties();
+#endif
+
+                foreach (var p in props.Where(x => x.Name.StartsWith("Item", StringComparison.Ordinal)).OrderBy(x => x.Name))
+                    yield return p.GetValue(tuple, null);
+
+                if (type.GetGenericTypeDefinition() == typeof(Tuple<,,,,,,,>))
+                    tuple = type.GetProperty("Rest").GetValue(tuple, null);
+                else
+                    break;
+            }
+        }
+#endif
+
+        private static object GetExpressionValue(Expression<Func<string, object>> expr)
+        {
+            var constExpr = expr.Body as ConstantExpression;
+            return constExpr != null ? constExpr.Value : expr.Compile()("");
+        }
+
+        private static object GetDefaultValue(Type type)
+        {
+            return type
+#if WIN_RT || PCL
+                .GetTypeInfo()
+#endif
+                .IsValueType ? Activator.CreateInstance(type) : null;
+        }
+
+        internal static IEnumerable<KeyValuePair<string, object>> ExpressionsToDictionary(IEnumerable<Expression<Func<string, object>>> exprs)
+        {
+            return exprs.Select(x => new KeyValuePair<string, object>(x.Parameters[0].Name, GetExpressionValue(x)));
+        }
+
+        internal static string GetUrl(ConnectionOptions options, string baseUrl, bool needsVersion, string rest)
+        {
+            var result = new StringBuilder(baseUrl.TrimEnd('/'));
+            if (needsVersion)
+            {
+                result.Append('/');
+                result.Append((options ?? new ConnectionOptions()).ApiVersion);
+            }
+            result.Append('/');
+            result.Append(rest);
+            return result.ToString();
+        }
+
+        internal static string GetUrl(ConnectionOptions options, string apiName)
+        {
+            if (options == null) options = new ConnectionOptions();
+            return GetUrl(options, options.ApiUrl, true, apiName + ".json");
+        }
+
+        internal static readonly DateTimeOffset unixEpoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
+
+        internal static DateTimeOffset GetUnixTime(long seconds)
+        {
+            return unixEpoch.AddTicks(checked(seconds * 10000000));
+        }
+
+        internal static DateTimeOffset GetUnixTimeMs(long milliseconds)
+        {
+            return unixEpoch.AddTicks(checked(milliseconds * 10000));
+        }
+
+        private const string XRateLimitLimit = "x-rate-limit-limit";
+        private const string XRateLimitRemaining = "x-rate-limit-remaining";
+        private const string XRateLimitReset = "x-rate-limit-reset";
+
+        internal static RateLimit ReadRateLimit(HttpWebResponse response)
+        {
+            var limit = response.Headers[XRateLimitLimit];
+            var remaining = response.Headers[XRateLimitRemaining];
+            var reset = response.Headers[XRateLimitReset];
+            return limit != null && remaining != null && reset != null
+                ? new RateLimit()
+                {
+                    Limit = int.Parse(limit),
+                    Remaining = int.Parse(remaining),
+                    Reset = GetUnixTime(long.Parse(reset))
+                }
+                : null;
+        }
+
+#if !NET35
+        internal static RateLimit ReadRateLimit(AsyncResponse response)
+        {
+            if (!new[] { XRateLimitLimit, XRateLimitRemaining, XRateLimitReset }
+                .All(x => response.Headers.ContainsKey(x)))
+                return null;
+
+            var limit = response.Headers[XRateLimitLimit];
+            var remaining = response.Headers[XRateLimitRemaining];
+            var reset = response.Headers[XRateLimitReset];
+            return new RateLimit()
+            {
+                Limit = int.Parse(limit),
+                Remaining = int.Parse(remaining),
+                Reset = GetUnixTime(long.Parse(reset))
+            };
+        }
+#endif
+
+        private static KeyValuePair<string, object> GetReservedParameter(List<KeyValuePair<string, object>> parameters, string reserved)
+        {
+            return parameters.Single(kvp => kvp.Key == reserved);
+        }
+
+#if !ASYNC_ONLY
+        internal static T ReadResponse<T>(HttpWebResponse response, string jsonPath)
+        {
+            using (var sr = new StreamReader(response.GetResponseStream()))
+            {
+                var json = sr.ReadToEnd();
+                var result = CoreBase.Convert<T>(json, jsonPath);
+                var twitterResponse = result as ITwitterResponse;
+                if (twitterResponse != null)
+                {
+                    twitterResponse.RateLimit = ReadRateLimit(response);
+                    twitterResponse.Json = json;
+                }
+                return result;
+            }
+        }
+
+        internal static Task<AsyncResponse> ResponseCallback(this Task<AsyncResponse> task, CancellationToken cancellationToken)
+        {
+#if WIN_RT || PCL
+            return task.Done(async res =>
+            {
+                if(!res.Source.IsSuccessStatusCode)
+                {
+                    var tex = await TwitterException.Create(res).ConfigureAwait(false);
+                    if(tex != null)
+                        throw tex;
+                    res.Source.EnsureSuccessStatusCode();
+                }
+
+                return res;
+            }, cancellationToken).Unwrap();
+#else
+            return task.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    var wex = t.Exception.InnerException as WebException;
+                    if (wex != null)
+                    {
+                        var tex = TwitterException.Create(wex);
+                        if (tex != null)
+                            throw tex;
+                    }
+                    t.Exception.InnerException.Rethrow();
+                }
+
+                return t;
+            }, cancellationToken).Unwrap();
+#endif
+        }
+
+        internal static Task<T> ReadResponse<T>(this Task<AsyncResponse> t, Func<string, T> parse, CancellationToken cancellationToken)
+        {
+            return t.Done(res =>
+            {
+                var reg = cancellationToken.Register(res.Dispose);
+                return res.GetResponseStreamAsync()
+                    .Done(stream =>
+                    {
+                        try
+                        {
+                            using (var sr = new StreamReader(stream))
+                            {
+                                var json = sr.ReadToEnd();
+                                var result = parse(json);
+                                var twitterResponse = result as ITwitterResponse;
+                                if (twitterResponse != null)
+                                {
+                                    twitterResponse.RateLimit = ReadRateLimit(res);
+                                    twitterResponse.Json = json;
+                                }
+                                return result;
+                            }
+                        }
+                        finally
+                        {
+                            reg.Dispose();
+                            cancellationToken.ThrowIfCancellationRequested();
+                        }
+                    }, cancellationToken);
+            }, cancellationToken).Unwrap();
+        }
+
+        internal static Task Delay(int millisecondsDelay, CancellationToken cancellationToken)
+        {
+#if NET40
+            var tcs = new TaskCompletionSource<Unit>();
+            if (cancellationToken.IsCancellationRequested)
+            {
+                tcs.SetCanceled();
+            }
+            else
+            {
+                var reg = default(CancellationTokenRegistration);
+                Timer timer = null;
+                timer = new Timer(
+                    _ =>
+                    {
+                        reg.Dispose();
+                        timer?.Dispose();
+                        tcs.TrySetResult(Unit.Default);
+                    },
+                    null, millisecondsDelay, Timeout.Infinite
+                );
+                reg = cancellationToken.Register(() =>
+                {
+                    timer?.Dispose();
+                    tcs.TrySetCanceled();
+                });
+            }
+            return tcs.Task;
+#else
+            return Task.Delay(millisecondsDelay, cancellationToken);
+#endif
+        }
+#endif
+    }
+
+    internal static class ExceptionExtensions
+    {
+        internal static void Rethrow(this Exception ex)
+        {
+#if NET45 || WIN_RT || WP
+            System.Runtime.ExceptionServices
+                .ExceptionDispatchInfo.Capture(ex)
+                .Throw();
+#else
+            throw ex;
+#endif
+        }
+    }
+
+
+}


### PR DESCRIPTION
- CoreTweetを0.6.4に更新
- 非同期動画アップロードに対応
- 最大140秒、512MiBまでの動画アップロードを可能に
- CoreTweetの仕様が今のところアレなのでコードを借用
